### PR TITLE
Fix indentaion mismatch

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -98,9 +98,9 @@ class LatextoolsJumpToPdfCommand(sublime_plugin.TextCommand):
 
 		view = self.view
 
-    file_name = view.file_name()
+		file_name = view.file_name()
 		if not is_tex_file(file_name):
-      if from_keybinding:
+			if from_keybinding:
 				sublime.error_message(
 					"%s is not a TeX source file: cannot jump." %
 					(os.path.basename(file_name),))


### PR DESCRIPTION
The combination of space and tab indentation in jumpToPDF.py -possibly appears in b27fc391b2e0c7298d7e2be2472f3642e25ed3d2 (merging https://github.com/SublimeText/LaTeXTools/pull/1472)
prevents PDF viewer from opening after build, and removes View PDF and Jump to PDF commands from command list (See https://github.com/SublimeText/LaTeXTools/issues/1539).